### PR TITLE
Add bearer token property so ApiClient

### DIFF
--- a/Centrify.Samples.DotNet.ApiLib/ApiClient.cs
+++ b/Centrify.Samples.DotNet.ApiLib/ApiClient.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -29,6 +30,44 @@ namespace Centrify.Samples.DotNet.ApiLib
         public ApiClient(RestClient authenticatedClient)
         {
             m_restClient = authenticatedClient;
+        }
+
+        public ApiClient(string endpointBase, string bearerToken)
+        {
+            m_restClient = new RestClient(endpointBase);
+            m_restClient.BearerToken = bearerToken;
+        }
+
+        public string BearerToken
+        {
+            get
+            {
+                if (m_restClient.BearerToken != null)
+                {
+                    return m_restClient.BearerToken;
+                }
+                else
+                {
+                    if (m_restClient.Cookies != null)
+                    {
+                        CookieCollection endpointCookies = m_restClient.Cookies.GetCookies(new Uri(m_restClient.Endpoint));
+                        if (endpointCookies != null)
+                        {
+                            Cookie bearerCookie = endpointCookies[".ASPXAUTH"];
+                            if (bearerCookie != null)
+                            {
+                                return bearerCookie.Value;
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+
+            set
+            {
+                m_restClient.BearerToken = value;
+            }
         }
 
         // Illustrates locking a CUS user via /cdirectoryservice/setuserstate

--- a/Centrify.Samples.DotNet.ApiLib/RestClient.cs
+++ b/Centrify.Samples.DotNet.ApiLib/RestClient.cs
@@ -37,6 +37,11 @@ namespace Centrify.Samples.DotNet.ApiLib
             Endpoint = DEFAULT_ENDPOINT;
         }
 
+        public string BearerToken
+        {
+            get; set;
+        }
+
         public RestClient(string podEndpointName)
         {
             Endpoint = podEndpointName;
@@ -57,10 +62,15 @@ namespace Centrify.Samples.DotNet.ApiLib
             var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(Endpoint + method);
 
             request.Method = "POST";
-            request.ContentLength = 0;            
+            request.ContentLength = 0;
             request.ContentType = "application/json; charset=utf-8";
             request.Headers.Add("X-CENTRIFY-NATIVE-CLIENT", "1");
             request.Timeout = 120000;
+
+            if (BearerToken != null)
+            {
+                request.Headers.Add("Authorization", "Bearer " + BearerToken);
+            }
 
             // Carry cookies from call to call
             if (Cookies == null)

--- a/Centrify.Samples.DotNet.Client/Program.cs
+++ b/Centrify.Samples.DotNet.Client/Program.cs
@@ -26,11 +26,17 @@ namespace Centrify.Samples.DotNet.Client
             // All api's require that the user first be authenticated, doing so using the sample InteractiveLogin.Authenticate
             //  supports most of the MFA mechanisms provided by CIS (Email, SMS, OTP, OATH, Phone Call, Security Question), and
             //  returns us a client which has the appropriate authentication cookies in place.
-            RestClient authenticatedRestClient = InteractiveLogin.Authenticate("https://devdog.centrify.com");
+            RestClient authenticatedRestClient = InteractiveLogin.Authenticate("https://cloud.centrify.com");
 
             // We can now use that client to perform actions as the authenticated user, the ApiClient class has a method per
             //  REST api, which uses a RestClient for communication:
             ApiClient apiClient = new ApiClient(authenticatedRestClient);
+
+            // If we wanted to convert this authenticated session into a useable bearer token for headless activity, we can get it:
+            // Console.WriteLine("Bearer token for this session: {0}", apiClient.BearerToken);
+
+            // Alternatively, if we already have a bearer token, we can use that:
+            // ApiClient apiClient = new ApiClient("https://cloud.centrify.com", ExistingBearerToken);
 
             try
             {
@@ -93,7 +99,7 @@ namespace Centrify.Samples.DotNet.Client
                 #region Update a username/password applications stashed credentials
                 // Update the credentials for my UP app...
                 // apiClient.UpdateApplicationDE("someAppKeyFromGetUPData", "newUsername", "newPassword");
-                #endregion
+                #endregion                
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Allows ApiClient to work with an existing/available bearer token, or to retrieve a token after performing interactive auth
